### PR TITLE
Update test.txt bitsandbytes to cover aarch64 platform_machine

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,8 +17,8 @@ absl-py # thunder/benchmarks/test_benchmark_litgpt.py
 pandas # thunder/benchmarks/test_benchmark_litgpt.py
 xlsxwriter # thunder/benchmarks/test_benchmark_litgpt.py
 jsonargparse # thunder/benchmarks/benchmark_litgpt.py
-bitsandbytes>=0.44,<0.45; 'arm' not in platform_machine
-bitsandbytes>=0.42,<0.43; 'arm' in platform_machine
+bitsandbytes>=0.44,<0.45; 'arm' not in platform_machine and 'aarch' not in platform_machine
+bitsandbytes>=0.42,<0.43; 'arm' in platform_machine or 'aarch' in platform_machine
 transformers==4.52.4 # for test_networks.py
 
 # Installs JAX on Linux and MacOS


### PR DESCRIPTION
On machines like GB200, the platform_machine would return aarch64, making 'arm' not in platform_machine true and therefore it tried to install >=0.44,<0.45 on arm and it would not be found.  We want it to evaluate to false by adding 'aarch' not in platform_machine.

```
ERROR: Could not find a version that satisfies the requirement bitsandbytes<0.45,>=0.44 (from versions: 0.31.8, 0.32.0, 0.32.1, 0.32.2, 0.32.3, 0.33.0, 0.33.1, 0.34.0, 0.35.0, 0.35.1, 0.35.2, 0.35.3, 0.35.4, 0.36.0, 0.36.0.post1, 0.36.0.post2, 0.37.0, 0.37.1, 0.37.2, 0.38.0, 0.38.0.post1, 0.38.0.post2, 0.38.1, 0.39.0, 0.39.1, 0.40.0, 0.40.0.post1, 0.40.0.post2, 0.40.0.post3, 0.40.0.post4, 0.40.1, 0.40.1.post1, 0.40.2, 0.41.0, 0.41.1, 0.41.2, 0.41.2.post1, 0.41.2.post2, 0.41.3, 0.41.3.post1, 0.41.3.post2, 0.42.0, 0.46.0, 0.46.1)                                                                                                       
ERROR: No matching distribution found for bitsandbytes<0.45,>=0.44    
```

 
